### PR TITLE
Update External Port to 4200

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd OpenHands
 docker-compose up -d
 ```
 
-The application will be available at http://localhost:3000
+The application will be available at http://localhost:4200
 
 ## Installation Options
 
@@ -62,7 +62,7 @@ docker run -it --rm --pull=always \
     -e LOG_ALL_EVENTS=true \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.openhands-state:/.openhands-state \
-    -p 3000:3000 \
+    -p 4200:3000 \
     --add-host host.docker.internal:host-gateway \
     --name openhands-app \
     docker.all-hands.dev/all-hands-ai/openhands:0.19

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       args:
         - NODE_ENV=development
     ports:
-      - "3000:3000"
+      - "4200:3000"
     environment:
       - SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.19-nikolaik
       - LOG_ALL_EVENTS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         - NODE_ENV=development
     ports:
-      - "3000:3000"
+      - "4200:3000"
     environment:
       - SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.19-nikolaik
       - LOG_ALL_EVENTS=true


### PR DESCRIPTION
This PR updates the external port to 4200 while keeping the internal port at 3000.

Changes:
1. docker-compose.yml:
   - Changed external port from 3000 to 4200
   - Internal port remains 3000

2. docker-compose.dev.yml:
   - Changed external port from 3000 to 4200
   - Internal port remains 3000

3. README.md:
   - Updated all port references
   - Updated documentation

The application will now be accessible at http://localhost:4200

To use:
```bash
# Production
docker-compose up -d
# Access at http://localhost:4200

# Development
docker-compose -f docker-compose.dev.yml up -d
# Access at http://localhost:4200
```